### PR TITLE
chatgpt-codex-full-20250726

### DIFF
--- a/exercises/practice/accumulate/accumulate.ts
+++ b/exercises/practice/accumulate/accumulate.ts
@@ -1,3 +1,7 @@
-export function accumulate(list: unknown, accumulator: unknown): never {
-  throw new Error('Remove this line and implement the function')
+export function accumulate<T, U>(list: T[], accumulator: (item: T) => U): U[] {
+  const result: U[] = []
+  for (const item of list) {
+    result.push(accumulator(item))
+  }
+  return result
 }

--- a/exercises/practice/acronym/acronym.ts
+++ b/exercises/practice/acronym/acronym.ts
@@ -1,3 +1,21 @@
-export function parse(phrase: unknown): unknown {
-  throw new Error('Remove this line and implement the function')
+export function parse(phrase: string): string {
+  const normalized = phrase
+    .replace(/[^A-Za-z\s-]/g, '')
+    .replace(/-/g, ' ')
+    .split(/\s+/)
+    .filter((w) => w.length > 0)
+
+  const letters: string[] = []
+  for (const word of normalized) {
+    letters.push(word[0])
+    for (let i = 1; i < word.length; i++) {
+      const char = word[i]
+      const prev = word[i - 1]
+      if (char >= 'A' && char <= 'Z' && !(prev >= 'A' && prev <= 'Z')) {
+        letters.push(char)
+      }
+    }
+  }
+
+  return letters.join('').toUpperCase()
 }

--- a/exercises/practice/anagram/anagram.ts
+++ b/exercises/practice/anagram/anagram.ts
@@ -1,9 +1,23 @@
 export class Anagram {
-  constructor(input: unknown) {
-    throw new Error('Remove this line and implement the function')
+  private readonly subject: string
+
+  constructor(input: string) {
+    this.subject = input
   }
 
-  public matches(...potentials: unknown[]): unknown {
-    throw new Error('Remove this line and implement the function')
+  private normalize(word: string): string {
+    return [...word.toLowerCase()].sort().join('')
+  }
+
+  public matches(...potentials: string[]): string[] {
+    const normalizedSubject = this.normalize(this.subject)
+    const subjectLower = this.subject.toLowerCase()
+    return potentials.filter((candidate) => {
+      const candidateLower = candidate.toLowerCase()
+      if (candidateLower === subjectLower) {
+        return false
+      }
+      return this.normalize(candidate) === normalizedSubject
+    })
   }
 }

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.ts
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.ts
@@ -1,3 +1,10 @@
-export function isArmstrongNumber(number: unknown): unknown {
-  throw new Error('Remove this line and implement the function')
+export function isArmstrongNumber(value: number | bigint): boolean {
+  const digits = value.toString()
+  const power = BigInt(digits.length)
+  let sum = 0n
+  for (const ch of digits) {
+    const digit = BigInt(ch)
+    sum += digit ** power
+  }
+  return sum === BigInt(value)
 }

--- a/exercises/practice/hello-world/hello-world.ts
+++ b/exercises/practice/hello-world/hello-world.ts
@@ -1,3 +1,3 @@
 export function hello(): string {
-  return 'Goodbye, Mars!'
+  return 'Hello, World!'
 }

--- a/exercises/practice/leap/leap.ts
+++ b/exercises/practice/leap/leap.ts
@@ -1,3 +1,9 @@
-export function isLeap() {
-  throw new Error('Remove this line and implement the function')
+export function isLeap(year: number): boolean {
+  if (year % 4 !== 0) {
+    return false
+  }
+  if (year % 100 !== 0) {
+    return true
+  }
+  return year % 400 === 0
 }

--- a/exercises/practice/two-fer/two-fer.ts
+++ b/exercises/practice/two-fer/two-fer.ts
@@ -2,12 +2,6 @@
  * This stub is provided to make it straightforward to get started.
  */
 
-export function twoFer(): string {
-  // ^                 ^   ^ this is called a return type; it's the type of the
-  // ^                 ^     value that is returned from this function
-  // ^                 ^
-  // ^                 parameters go here
-  // ^
-  // allows the tests to import this function and call it
-  // <-- Your code goes here. You may remove all the commentary in this file.
+export function twoFer(name = 'you'): string {
+  return `One for ${name}, one for me.`
 }


### PR DESCRIPTION
## Summary
- implement `accumulate` without using `map`
- handle camel case in `acronym`
- support `BigInt` values for `armstrong-numbers`
- add anagram solver class

## Testing
- `corepack yarn jest exercises/practice/accumulate/accumulate.test.ts`
- `corepack yarn jest exercises/practice/acronym/acronym.test.ts`
- `corepack yarn jest exercises/practice/armstrong-numbers/armstrong-numbers.test.ts`
- `corepack yarn jest exercises/practice/anagram/anagram.test.ts`
- `corepack yarn jest exercises/practice/hello-world/hello-world.test.ts`
- `corepack yarn jest exercises/practice/two-fer/two-fer.test.ts`
- `corepack yarn jest exercises/practice/leap/leap.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68846e3e7e3083339d02e52004652162